### PR TITLE
Update example DAGs for Registry readiness

### DIFF
--- a/dags/feature-eng.py
+++ b/dags/feature-eng.py
@@ -1,5 +1,5 @@
 """
-### Feature Engineering Pipeline to use with MLflow provider example DAGs.
+### Feature Engineering with MLflow
 
 Generates synthetic data and performs feature engineering.
 """
@@ -8,9 +8,8 @@ from pendulum import datetime
 import logging
 
 from airflow.decorators import dag
-from astro import sql as aql 
+from astro import sql as aql
 from astro.sql.table import Table, Metadata
-from airflow import Dataset
 
 from pandas import DataFrame
 
@@ -32,7 +31,7 @@ test_sample = {
 
 @dag(
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     tags=["example"],
     default_view="graph",
     catchup=False,
@@ -41,16 +40,16 @@ test_sample = {
 def feature_eng():
 
     @aql.transform
-    def get_data(input_table: Table): 
-        return """ 
-            SELECT 
+    def get_data(input_table: Table):
+        return """
+            SELECT
                 sepal_length_cm,
                 sepal_width_cm,
                 petal_length_cm,
                 petal_width_cm
             FROM {{input_table}}
-        """ 
-    
+        """
+
     @aql.dataframe(columns_names_capitalization="lower")
     def generate_features(
         df: DataFrame,
@@ -65,23 +64,23 @@ def feature_eng():
             max_value = df.describe()[col]['max']
             max_values.append(max_value)
         logging.info(f"Max values for each column: {max_values}")
-            
+
         min_values = []
         for col in df.columns:
             min_value = df.describe()[col]['min']
             min_values.append(min_value)
         logging.info(f"Min values for each column: {min_values}")
-        
+
         increase_max_by = 0
         if max_increase_limit > 0:
             increase_max_by = [random.uniform(x, x+max_increase_limit) for x in max_values]
         logging.info(f"Randomly increase max by: {increase_max_by}")
-        
+
         decrease_min_by = 0
         if min_decrease_limit > 0:
             decrease_min_by = [random.uniform(x-min_decrease_limit, x) for x in  min_values]
         logging.info(f"Randomly decrease min by: {decrease_min_by}")
-        
+
         synthetic_records = []
         for i in range(num_new_records):
             record = []
@@ -91,7 +90,7 @@ def feature_eng():
                     new_value = 0.11
                 record.append(new_value)
             synthetic_records.append(record)
-        
+
         synthetic_records = DataFrame(data=synthetic_records, columns=df.columns)
         return synthetic_records
 

--- a/dags/generate-true-values.py
+++ b/dags/generate-true-values.py
@@ -1,22 +1,20 @@
 """
-### Generate True Values DAG to use with MLflow Provider example DAGs
+### Generate True Values with MLflow
 
 Artificially generates feedback on the predictions made by the model in the predict DAG.
 """
 
 from pendulum import datetime
-import logging
 
 from airflow.decorators import dag
-from astro import sql as aql 
+from astro import sql as aql
 from astro.sql.table import Table, Metadata
-from airflow import Dataset
 
 from pandas import DataFrame
 
 @dag(
     start_date=datetime(2022, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     tags=["example"],
     default_view="grid",
     catchup=False,
@@ -25,18 +23,18 @@ from pandas import DataFrame
 def generate_true_values():
 
     @aql.transform
-    def get_data(input_table: Table): 
-        return """ 
-            SELECT 
+    def get_data(input_table: Table):
+        return """
+            SELECT
                 feature_id,
                 prediction
             FROM {{input_table}}
         """
-    
+
     @aql.dataframe(columns_names_capitalization="lower")
     def generate_true_values(predictions: DataFrame):
         import random
-        
+
         predicted_values = predictions['prediction'].to_list()
 
         feedback=[]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-# git+https://<your-github-token>@github.com/astronomer/airflow-provider-mlflow.git@main
 lightgbm==3.2.1
 apache-airflow-providers-slack==7.2.0
 astro-sdk-python[postgres]==1.5.2


### PR DESCRIPTION
Cleaning up the example DAGs prior to publishing on the Registry as well as a small fix for a DAG-parsing bug:
- Updated DAG titles in docstrings
- Removed ununsed imports
- Prefer `schedule` over deprecated `schedule_interval` DAG param
- Removed commented lines
- Fix operator use causing parsing failures of the "predict" DAG