### PR TITLE
Correct DAG file paths in .astro-registry.yaml file

### DIFF
--- a/.astro-registry.yaml
+++ b/.astro-registry.yaml
@@ -6,8 +6,8 @@ categories:
   - ETL/ELT
 # List of DAGs that should be published to the Astronomer Registry.
 dags:
-  - path: dags/feature_eng.py
-  - path: dags/monitor_features.py
+  - path: dags/feature-eng.py
+  - path: dags/monitor-features.py
   - path: dags/retrain.py
   - path: dags/predict.py
-  - path: dags/generate_true_values.py
+  - path: dags/generate-true-values.py


### PR DESCRIPTION
The file paths in the `.astro-registry.yaml` file were incorrect for a few DAG files; the YAML specified underscores while the file itself used hyphens. This discrepancy was causing some DAGs to not be collected from the repo for publication to the Registry.